### PR TITLE
feat :art: Add output format to profile list

### DIFF
--- a/oks_cli/profile.py
+++ b/oks_cli/profile.py
@@ -134,7 +134,7 @@ def list_profiles(output):
         profiles[key].pop('password', None)
         # Add endpoint and JWT to dict
         profiles[key].update({'endpoint': endpoint})
-        profiles[key].update({'jwt_auth': profiles[key].get("jwt", False)})
+        profiles[key].update({'jwt': jwt})
 
         if output == 'wide':
             lines.append("Profile: {} Account type: {} Region: {} Endpoint: {} Enabled JWT auth: {}".format(

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -8,6 +8,23 @@ def test_profile_list_command():
     assert result.exit_code == 0
     assert "There are no profiles" in result.output
 
+def test_profile_list_command_yaml():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["profile", "list", "--output", "yaml"])
+    assert result.exit_code == 0
+    assert "There are no profiles" in result.output
+
+def test_profile_list_command_jsonl():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["profile", "list", "--output", "json"])
+    assert result.exit_code == 0
+    assert "There are no profiles" in result.output
+
+def test_profile_list_command_widel():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["profile", "list", "--output", "wide"])
+    assert result.exit_code == 0
+    assert "There are no profiles" in result.output
 
 def test_profile_add_command():
     runner = CliRunner()


### PR DESCRIPTION
Add json, yaml, table output format to profile list command. These options have been added in order to be consistent with orher outputs from sub-commands such as `cluster list`, `project list`, etc...

Default output to:

```bash
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+
|     PROFILE     | ACCOUNT TYPE |        REGION       |                         ENDPOINT                         | JWT ENABLED |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+
|     default     |    ak/sk     |      eu-west-2      |      https://api.eu-west-2.oks.outscale.com/api/v2/      |    False    |
| cloud-pi-native |    ak/sk     | cloudgouv-eu-west-1 | https://api.cloudgouv-eu-west-1.oks.outscale.com/api/v2/ |    False    |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+
```

Other outputs available:

*YAML*
```yaml
default:
  region_name: eu-west-2
  type: ak/sk
  endpoint: https://api.eu-west-2.oks.outscale.com/api/v2/
  jwt_auth: false
cloud-pi-native:
  region_name: cloudgouv-eu-west-1
  type: ak/sk
  endpoint: https://api.cloudgouv-eu-west-1.oks.outscale.com/api/v2/
  jwt_auth: false
```

*JSON*
```json
{
    "default": {
        "region_name": "eu-west-2",
        "type": "ak/sk",
        "endpoint": "https://api.eu-west-2.oks.outscale.com/api/v2/",
        "jwt_auth": false
    },
    "cloud-pi-native": {
        "region_name": "cloudgouv-eu-west-1",
        "type": "ak/sk",
        "endpoint": "https://api.cloudgouv-eu-west-1.oks.outscale.com/api/v2/",
        "jwt_auth": false
    }
}
```

*WIDE* (original)
```bash
Profile: default Account type: ak/sk Region: eu-west-2 Endpoint: https://api.eu-west-2.oks.outscale.com/api/v2/ Enabled JWT auth: False
Profile: cloud-pi-native Account type: ak/sk Region: cloudgouv-eu-west-1 Endpoint: https://api.cloudgouv-eu-west-1.oks.outscale.com/api/v2/ Enabled JWT auth: False
```