### PR TITLE
:sparkle: feat: Support OKS_PROFILE environment variable

### DIFF
--- a/oks_cli/utils.py
+++ b/oks_cli/utils.py
@@ -309,8 +309,13 @@ def login_profile(name):
     Raises an exception if the profile does not exist or lacks required info.
     """
     _, PROFILE_FILE = get_config_path()
+
+    # check is profile name is defined by user as environment variable
     if name is None:
-        name = "default"
+        if os.getenv('OKS_PROFILE') is None:
+            name = "default"
+        else:
+            name = os.getenv('OKS_PROFILE')
 
     if os.path.exists(PROFILE_FILE):
         with open(PROFILE_FILE, 'r') as file:


### PR DESCRIPTION
User can set `OKS_PROFILE` environment variable as default profile when running any `oks-cli` command without the need to set `--profile` option