### PR TITLE
:art: feat: Required --type option when running install-completion command

### DIFF
--- a/oks_cli/main.py
+++ b/oks_cli/main.py
@@ -82,7 +82,7 @@ def version():
     print(importlib.metadata.version(__package__))
 
 @cli.command("install-completion", help="Install shell completion scripts.")
-@click.option('--type', help="Shell")
+@click.option('--type', required=True, help="Shell, supported [bash,zsh]")
 def install_completion(type):
     """Install shell completion scripts for the CLI."""
     install_completions(type)

--- a/oks_cli/utils.py
+++ b/oks_cli/utils.py
@@ -710,17 +710,6 @@ def find_shell_profile(home, shell_type):
 def install_completions(shell_type):
     """Install shell completion scripts for bash or zsh."""
     home = os.path.expanduser('~')
-
-    if shell_type is None:
-        try:
-            shell_pid = os.getppid()
-            result = subprocess.run(['ps', '-p', str(shell_pid), '-o', 'comm='], capture_output=True, text=True)
-            shell_name = result.stdout.strip()
-            
-            shell_type = os.path.basename(shell_name)
-        except subprocess.SubProcessError:
-            click.echo("Failed to determine shell type, please specify it by --type")
-
     completion_dir = os.path.join(home, ".oks_cli", "completions")
     os.makedirs(completion_dir, exist_ok=True)
 
@@ -752,7 +741,7 @@ def install_completions(shell_type):
                 click.style('source "$HOME/.oks_cli/completions/oks-cli.sh"\n', bold=True)
             )
     else:
-        click.echo(f"Shell completions for {shell_type} are not implemented.")
+        raise click.UsageError(f"Shell completions for {shell_type} are not implemented.")
 
 def transform_tuple(data):
     """Convert tuple to list unless it contains only an empty string."""

--- a/tests/test_install_completion.py
+++ b/tests/test_install_completion.py
@@ -1,0 +1,24 @@
+from click.testing import CliRunner
+from oks_cli.main import cli
+# from unittest.mock import patch, MagicMock
+
+def test_install_completion_command_type_required():
+    """ Test --type option is required """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install-completion"])
+    assert result.exit_code == 2
+    assert "Missing option '--type'" in result.output
+
+def test_install_completion_command_wrong_type():
+    """ Test --type supported values """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install-completion", "--type", "fake-shell"])
+    assert result.exit_code == 2
+    assert "Shell completions for fake-shell are not implemented" in result.output
+
+def test_install_completion_command():
+    """ Test working shell """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install-completion", "--type", "bash"])
+    assert result.exit_code == 0
+    assert "Autocompletion installed for bash" in result.output


### PR DESCRIPTION
This changes introduces the fact that when the user wants to create a shell completion script s/he needs to specify `--type` option to specify the shell. This simplifies function that creates completion script. Tests have been added.