### PR TITLE
:art: feat: Show profile and region when listing projects and clusters

### DIFF
--- a/oks_cli/cluster.py
+++ b/oks_cli/cluster.py
@@ -82,6 +82,8 @@ def cluster_list(ctx, project_name, cluster_name, deleted, plain, msword, watch,
     project_name, cluster_name, profile = ctx_update(ctx, project_name, cluster_name, profile)
     login_profile(profile)
 
+    profile_name = os.getenv('OKS_PROFILE')
+    region_name = os.getenv('OKS_REGION')
     project_id = find_project_id_by_name(project_name)
     cluster_id = get_cluster_id()
 
@@ -93,7 +95,7 @@ def cluster_list(ctx, project_name, cluster_name, deleted, plain, msword, watch,
     if deleted:
         params['deleted'] = True
 
-    field_names = ["NAME", "CREATED", "UPDATED", "STATUS", "DEFAULT"]
+    field_names = ["CLUSTER", "PROFILE", "REGION", "CREATED", "UPDATED", "STATUS", "DEFAULT"]
 
     data = do_request("GET", 'clusters', params=params)
 
@@ -140,7 +142,7 @@ def cluster_list(ctx, project_name, cluster_name, deleted, plain, msword, watch,
         updated_at = dateutil.parser.parse(cluster['statuses']['updated_at'])
         now = datetime.datetime.now(tz = created_at.tzinfo)
 
-        row = [name, human_readable.date_time(now - created_at), human_readable.date_time(now - updated_at), msg, default]
+        row = [name, profile_name, region_name, human_readable.date_time(now - created_at), human_readable.date_time(now - updated_at), msg, default]
 
         if output == "wide":
             row.insert(0, cluster['id'])

--- a/oks_cli/project.py
+++ b/oks_cli/project.py
@@ -72,7 +72,9 @@ def project_list(ctx, project_name, deleted, plain, msword, uuid, watch, output,
     project_name, _, profile = ctx_update(ctx, project_name, None, profile)
     login_profile(profile)
 
+    profile_name = os.getenv('OKS_PROFILE')
     project_id = get_project_id()
+
     params = {}
     if project_name:
         params['name'] = project_name
@@ -86,7 +88,7 @@ def project_list(ctx, project_name, deleted, plain, msword, uuid, watch, output,
         print_output(data, output)
         return
 
-    field_names = ["NAME", "CREATED", "UPDATED", "STATUS", "DEFAULT"]
+    field_names = ["PROJECT", "PROFILE", "REGION", "CREATED", "UPDATED", "STATUS", "DEFAULT"]
     if uuid:
         field_names.append('UUID')
 
@@ -120,11 +122,12 @@ def project_list(ctx, project_name, deleted, plain, msword, uuid, watch, output,
         else:
             default = ""
 
+        region_name = project.get('region')
         created_at = dateutil.parser.parse(project['created_at'])
         updated_at = dateutil.parser.parse(project['updated_at'])
         now = datetime.datetime.now(tz=created_at.tzinfo)
 
-        row = [name, human_readable.date_time(now - created_at), human_readable.date_time(now - updated_at), msg, default]
+        row = [name, profile_name, region_name, human_readable.date_time(now - created_at), human_readable.date_time(now - updated_at), msg, default]
         if uuid:
             row.append(project['id'])
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -5,6 +5,29 @@ from unittest.mock import patch, MagicMock
 import json 
 import yaml
 
+# Test the "cluster list" command: verifies region and profile are shown
+@patch("oks_cli.utils.requests.request")
+def test_cluster_list_command_with_region_and_profile(mock_request, add_default_profile):
+    mock_request.side_effect = [
+        MagicMock(status_code=200, headers = {}, json=lambda: {"ResponseContext": {}, "Projects": [{"id": "12345"}]}),
+        MagicMock(status_code=200, headers = {}, json=lambda:
+                  {"ResponseContext": {},
+                   "Clusters": [
+                       {"id": "12345", "name": "test",
+                        "statuses": {"status": "ready",
+                                     "created_at": "2019-08-24T14:15:22Z",
+                                     "updated_at": "2019-08-24T14:15:22Z"}
+                        }
+                    ]
+                  }),
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["cluster", "list", "-p", "test", "-c", "test"])
+    assert result.exit_code == 0
+    assert 'eu-west-2' in result.output
+    assert 'default' in result.output
+
 # Test the "cluster list" command: verifies listing clusters in a project
 @patch("oks_cli.utils.requests.request")
 def test_cluster_list_command(mock_request, add_default_profile):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,6 +5,27 @@ import yaml
 import json 
 
 # START PROJECT LIST COMMAND
+# Test the "project list" command: verifies region and profile are shown
+@patch("oks_cli.utils.requests.request")
+def test_project_list_command_with_region_and_profile(mock_request, add_default_profile):
+    mock_request.side_effect = [
+        MagicMock(status_code=200, headers = {}, json=lambda: {
+            "ResponseContext": {},
+            "Projects": [
+                {"id": "12345",
+                 "name":"test",
+                 "created_at": "2019-08-24T14:15:22Z",
+                 "updated_at": "2019-08-24T14:15:22Z",
+                 "status": "ready",
+                 "region":"eu-west-2"}]})
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["project", "list"])
+    assert result.exit_code == 0
+    assert 'eu-west-2' in result.output
+    assert 'default' in result.output
+
 # Test the "project list" command: verifies listing 1 projects with json
 @patch("oks_cli.utils.requests.request")
 def test_project_list_command_json(mock_request, add_default_profile):


### PR DESCRIPTION
This PR is a proposal to add some, I think useful information about project and cluster when listing them. It can be disturbing when user have multiple projects and clusters to remember which cluster belongs to which profile and region as well as for projects:

Before:
```bash
➜  oks-cli project list
+--------------+---------------+---------------+------------+---------+
|     NAME     |    CREATED    |    UPDATED    |   STATUS   | DEFAULT |
+--------------+---------------+---------------+------------+---------+
| cerba-theodo |  3 months ago |  23 days ago  |   ready    |         |
|  clusterapi  |   9 days ago  |   9 days ago  |   ready    |         |
+--------------+---------------+---------------+------------+---------+
➜  oks-cli cluster list --project-name clusterapi
+-----------------------+---------------+---------------+------------+---------+
|          NAME         |    CREATED    |    UPDATED    |   STATUS   | DEFAULT |
+-----------------------+---------------+---------------+------------+---------+
| clusterapi-management |   9 days ago  |   9 days ago  |   ready    |         |
|   anotherclusterapi   |  5 hours ago  |  5 hours ago  |   ready    |         |
+-----------------------+---------------+---------------+------------+---------+
```

Proposed new output:
```bash
➜  oks-cli project list
+--------------+---------+-----------+---------------+---------------+------------+---------+
|   PROJECT    | PROFILE |   REGION  |    CREATED    |    UPDATED    |   STATUS   | DEFAULT |
+--------------+---------+-----------+---------------+---------------+------------+---------+
| cerba-theodo | default | eu-west-2 |  3 months ago |  23 days ago  |   ready    |         |
|  clusterapi  | default | eu-west-2 |   9 days ago  |   9 days ago  |   ready    |         |
+--------------+---------+-----------+---------------+---------------+------------+---------+
➜  oks-cli cluster list --project-name clusterapi   
+-----------------------+---------+-----------+---------------+---------------+------------+---------+
|        CLUSTER        | PROFILE |   REGION  |    CREATED    |    UPDATED    |   STATUS   | DEFAULT |
+-----------------------+---------+-----------+---------------+---------------+------------+---------+
| clusterapi-management | default | eu-west-2 |   9 days ago  |   9 days ago  |   ready    |         |
|   anotherclusterapi   | default | eu-west-2 |  5 hours ago  |  5 hours ago  |   ready    |         |
+-----------------------+---------+-----------+---------------+---------------+------------+---------+
```

You can notice 2 new columns, `PROFILE` and `REGION`.