### PR TITLE
Feat: set default output per profile

### DIFF
--- a/oks_cli/profile.py
+++ b/oks_cli/profile.py
@@ -119,7 +119,7 @@ def delete_profile(profile_name, force):
         click.echo(f"Profile {profile_name_bold} has been successfully deleted")
 
 @profile.command('list', help="List existing profiles")
-@click.option('--output', '-o', type=click.Choice(["json", "yaml", "table", "text"]), help="Specify output format, by default is text")
+@click.option('--output', '-o', type=click.Choice(["json", "yaml", "table", "wide"]), help="Specify output format, by default is wide")
 def list_profiles(output):
     """Display all configured profiles with their settings."""
     profiles = profile_list()

--- a/oks_cli/utils.py
+++ b/oks_cli/utils.py
@@ -361,6 +361,9 @@ def login_profile(name):
         if 'region_name' in profiles[name]:
             os.environ["OKS_REGION"] = profiles[name]['region_name']
 
+        if 'output' in profiles[name]:
+            os.environ["OKS_DEFAULT_OUTPUT"] = profiles[name]['output']
+
         return profiles[name]
 
     return {}


### PR DESCRIPTION
This PR introduces a new key in the profile file `config.json` in order to support default command outputs for user profiles.
The user will be allowed to set an output format for each of his/her individual profiles. Thus, (s)he will not to have to specify an output format for each command that support this option.

Functions with `--output` option available, does not support the default output format from profiles .It will be introduce later in another PR.

For profile without default output, the listing show in bold `Update profile` message in `output` column as shown below:

```bash
$  oks-cli profile list -o table
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
| Profile         | Account type | Region              | Endpoint                                                 | JWT enabled | Default output |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
| cloud-pi-native | ak/sk        | cloudgouv-eu-west-1 | https://api.cloudgouv-eu-west-1.oks.outscale.com/api/v2/ | False       | json           |
| default         | ak/sk        | eu-west-2           | https://api.eu-west-2.oks.outscale.com/api/v2/           | False       | json           |
| test            | ak/sk        | eu-west-2           | okms.ppd-eu-west-2.outscale.com                          | False       | Update profile |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
```

When a profile is created, if not specified, the default output is set to `json`

```bash
$  oks-cli profile add --profile-name test --access-key XXXXX --secret-key YYYY --region eu-west-2 --endpoint okms.ppd-eu-west-2.outscale.com
Profile test has been successfully added

$ oks-cli profile list -o table                                                                                                                           
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
| Profile         | Account type | Region              | Endpoint                                                 | JWT enabled | Default output |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
| cloud-pi-native | ak/sk        | cloudgouv-eu-west-1 | https://api.cloudgouv-eu-west-1.oks.outscale.com/api/v2/ | False       | json           |
| default         | ak/sk        | eu-west-2           | https://api.eu-west-2.oks.outscale.com/api/v2/           | False       | json           |
| test            | ak/sk        | eu-west-2           | okms.ppd-eu-west-2.outscale.com                          | False       | json           |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
```

Output formats supported at the moment are only `json` and`yaml`

```bash
$   oks-cli profile add --profile-name test --access-key XXXXX --secret-key YYYY --region eu-west-2 --endpoint okms.ppd-eu-west-2.outscale.com --output yaml
Profile test has been successfully added

$oks-cli profile list -o table                                                                                                                           
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
| Profile         | Account type | Region              | Endpoint                                                 | JWT enabled | Default output |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
| cloud-pi-native | ak/sk        | cloudgouv-eu-west-1 | https://api.cloudgouv-eu-west-1.oks.outscale.com/api/v2/ | False       | json           |
| default         | ak/sk        | eu-west-2           | https://api.eu-west-2.oks.outscale.com/api/v2/           | False       | json           |
| test            | ak/sk        | eu-west-2           | okms.ppd-eu-west-2.outscale.com                          | False       | yaml           |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
```

Profiles can be easily updated:

```bash
$  oks-cli profile update --profile-name test --output json
Profile test has been successfully updated
$   oks-cli profile list -o table                           
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
| Profile         | Account type | Region              | Endpoint                                                 | JWT enabled | Default output |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
| cloud-pi-native | ak/sk        | cloudgouv-eu-west-1 | https://api.cloudgouv-eu-west-1.oks.outscale.com/api/v2/ | False       | json           |
| default         | ak/sk        | eu-west-2           | https://api.eu-west-2.oks.outscale.com/api/v2/           | False       | json           |
| test            | ak/sk        | eu-west-2           | okms.ppd-eu-west-2.outscale.com                          | False       | json           |
+-----------------+--------------+---------------------+----------------------------------------------------------+-------------+----------------+
```

Available to discuss about this feature, comments welcome!
