### PR TITLE
✅ test: Pin Click to <8.3.0 to avoid ctx.invoke Sentinel.UNSET break

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         "certifi>=2024.8.30",
         "charset-normalizer>=3.3.2",
-        "click>=8.1.7",
+        "click>=8.1.7,<8.3.0",
         "colorama>=0.4.6",
         "idna>=3.10",
         "pyyaml>=6.0.2",


### PR DESCRIPTION
Click 8.3.0 changes ctx.invoke behavior: options not explicitly passed 
are now set to Sentinel.UNSET instead of None. 