### PR TITLE
fix: typo in error handler for install-completion

### DIFF
--- a/oks_cli/utils.py
+++ b/oks_cli/utils.py
@@ -920,7 +920,7 @@ def install_completions(shell_type):
             shell_name = result.stdout.strip()
 
             shell_type = os.path.basename(shell_name).lstrip('-')
-        except subprocess.SubProcessError:
+        except subprocess.SubprocessError:
             click.echo("Failed to determine shell type, please specify it by --type")
 
     completion_dir = os.path.join(home, ".oks_cli", "completions")


### PR DESCRIPTION
Fixes a Python typo in the error handler for  `oks-cli install-completion`.
I'm running the CLI in a container and did not have the `ps` command, so the code was reached. Also confirmed by `pylint -E`.